### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
+  before_action :move_to_index, except: [:show, :index]
+
 
   def index
     @products = Product.all.order(id: "DESC")
@@ -13,6 +15,20 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
   end
 
+  def edit
+    @product = Product.find(params[:id])
+    redirect_to root_path unless current_user.id == @product.user_id
+  end
+
+  def update
+    @product = Product.find(params[:id])
+    if @product.update(product_params)
+      redirect_to product_path
+    else
+      render :edit
+    end
+  end
+
   def create
     @product = Product.new(product_params)
     if @product.save
@@ -22,11 +38,14 @@ class ProductsController < ApplicationController
     end
   end
 
+  def move_to_index
+    redirect_to new_user_session_path unless user_signed_in?
+  end
+
   private
 
   def product_params
-    params.require(:product).permit(:image, :product_name, :description, :category_id, :prefecture_id, :status_id, :burden_id,
-                                    :day_id, :price).merge(user_id: current_user.id)
+    params.require(:product).permit(:image, :product_name, :description, :category_id,
+       :prefecture_id, :status_id, :burden_id, :day_id, :price).merge(user_id: current_user.id)
   end
-
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
-  before_action :move_to_index, except: [:show, :index]
+  before_action :find_product, only: [:edit, :update, :show]
+  before_action :not_user, only: [:edit, :update]
 
 
   def index
@@ -12,16 +13,12 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @product = Product.find(params[:id])
   end
 
   def edit
-    @product = Product.find(params[:id])
-    redirect_to root_path unless current_user.id == @product.user_id
   end
 
   def update
-    @product = Product.find(params[:id])
     if @product.update(product_params)
       redirect_to product_path
     else
@@ -38,14 +35,18 @@ class ProductsController < ApplicationController
     end
   end
 
-  def move_to_index
-    redirect_to new_user_session_path unless user_signed_in?
-  end
-
   private
 
   def product_params
     params.require(:product).permit(:image, :product_name, :description, :category_id,
        :prefecture_id, :status_id, :burden_id, :day_id, :price).merge(user_id: current_user.id)
+  end
+
+  def find_product
+    @product = Product.find(params[:id])
+  end
+
+  def not_user
+    redirect_to root_path unless current_user.id == @product.user_id
   end
 end

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -9,9 +9,7 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @product, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
     <div class="img-upload">

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -139,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', product_path(@product.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -3,14 +3,14 @@ app/assets/stylesheets/items/new.css %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), root_path %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @product, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :product_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all,  :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:burden_id, Burden.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:day_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -23,7 +23,7 @@
     </div>
 
   <% if user_signed_in? %>
-    <% if current_user.id == @product.user_id %> 
+    <%# <% if current_user.id == @product.user_id %>  %>
     <%= link_to "商品の編集", edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", product_path, method: :delete, class:"item-destroy" %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -23,10 +23,10 @@
     </div>
 
   <% if user_signed_in? %>
-    <%# <% if current_user.id == @product.user_id %>  %>
+    <% if current_user.id == @product.user_id %> 
     <%= link_to "商品の編集", edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", product_path, method: :delete, class:"item-destroy" %>
+    <%# <%= link_to "削除", product_path, method: :delete, class:"item-destroy" %> %>
     <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -23,7 +23,7 @@
     </div>
 
   <% if user_signed_in? %>
-    <% if current_user.id == @product.user_id %>
+    <% if current_user.id == @product.user_id %> 
     <%= link_to "商品の編集", edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", product_path, method: :delete, class:"item-destroy" %>


### PR DESCRIPTION
#what
- ログイン状態の出品者のみ、出品した商品の商品情報を編集できること
- 必要な情報を適切に入力すると、商品情報（商品画像・商品名・商品の状態など）を変更できること
- 何も編集せずに更新をしても画像無しの商品にならないこと
- ログイン状態の出品者のみ、出品した商品の商品情報編集ページに遷移できること
- ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
- ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移すること
→商品購入機能実装後に実装
- ログイン状態の出品者であっても、URLを直接入力して自身の売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
- 商品出品時とほぼ同じ見た目で商品情報編集機能が実装されていること
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示されること（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
- エラーハンドリングができていること（入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示されること）
- エラーハンドリングの際、1つのエラーに対して同じエラーメッセージが重複して表示されないこと
#why
商品情報編集機能の実装のため

# プルリクエストへ記載するgyazo
- ログイン状態の出品者は、商品情報編集ページに遷移できる動画
- https://gyazo.com/d8330ce78288d5c42abb3bb7c96bea42
- 正しく情報を記入すると、商品の情報を編集できる動画
- https://gyazo.com/cfda7e40a873e9c4844223f8cc3a4fda
- 入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
- https://gyazo.com/1e520f05d84660de23a8772ec73519de
- 何も編集せずに更新をしても画像無しの商品にならない動画
- https://gyazo.com/ec788b26ad6d8e32d5113763f5bd4fb4
- ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
- https://gyazo.com/a2c653351ddb5eef15973cad823818c4
- ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
- https://gyazo.com/1b97bf520fc7a6a7de4959d38c79aa80
- ログイン状態の出品者であっても、URLを直接入力して自身の売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
- →商品購入機能実装後に実装
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
- https://gyazo.com/4c48e5bb412ac58aabe20b9fba836dfd